### PR TITLE
Comment console.log in methodResume

### DIFF
--- a/groundDB.client.js
+++ b/groundDB.client.js
@@ -487,7 +487,7 @@ Ground.methodResume = function(names, connection) {
   _groundUtil.each(names, function(name) {
     _allowMethodResumeMap[name] = connection;
   });
-  console.log(_allowMethodResumeMap);
+  // console.log(_allowMethodResumeMap);
 };
 
 // Add settings for methods to skip or not when caching methods


### PR DESCRIPTION
I commented out the console.log because is the _pattern_ I see in the rest of the file. It is very annoying and I think was not intentional let that there.

Cheers.
