### PR TITLE
remove method handle multiple doc removes

### DIFF
--- a/lib/client/ground.db.js
+++ b/lib/client/ground.db.js
@@ -439,8 +439,11 @@ Ground.Collection = class GroundCollection {
   remove(selector, ...args) {
     // Order of saveDocument and remove call is not important
     // when removing a document. (why we don't need carrier for the result)
-    const doc = this._collection.findOne(selector);
-    doc && this.saveDocument(doc, true);
+    // only need the doc._id for removals
+    const docs = this._collection.find(selector, {'fields': {'_id': 1}}).fetch();
+    for(let doc of docs) {
+      this.saveDocument(doc, true);
+    }
     return this._collection.remove(selector, ...args);
   }
 


### PR DESCRIPTION
Ground:db only deletes 1 file from the backing store no matter how many minimongo documents are deleted.  see #190.

This is a simple fix